### PR TITLE
OHLC: rename currency to quote (setQuote), Makefile test/run without …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.1.0] - 2026-02-22
+
+### Changed
+- OHLC endpoint: renamed `setCurrency()` to `setQuote()` and request parameter from `currency` to `quote` to align with API response field names.
+
 ## [3.0.0] - 2026-02-19
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ RUN apk --no-cache add pcre-dev linux-headers ${PHPIZE_DEPS} \
   && apk del pcre-dev linux-headers ${PHPIZE_DEPS}
   
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
-COPY composer.json $APP_DIR/
+COPY composer.json composer.lock $APP_DIR/
+RUN composer install --no-interaction
 
-RUN composer install
+COPY . $APP_DIR/
+
+CMD ["./vendor/bin/phpunit"]

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Returns candlestick data for a currency pair on a given date, useful for chartin
 
 ```php
 $result = $currencyApi
-    ->setCurrency('EUR')
+    ->setQuote('EUR')
     ->setDate('2023-12-25')
     ->ohlc();
 ```
@@ -205,7 +205,7 @@ Example with all available methods:
 
 ```php
 $result = $currencyApi
-    ->setCurrency('EUR')
+    ->setQuote('EUR')
     ->setDate('2023-12-25')
     ->setBase('GBP')
     ->setInterval('1h')
@@ -216,7 +216,7 @@ $result = $currencyApi
 
 | Methods | Description |
 | --- | --- |
-| `setCurrency()` | The currency to retrieve OHLC data for. Three letter ISO 4217 currency code. **Required**. |
+| `setQuote()` | The quote currency to retrieve OHLC data for. Three letter ISO 4217 currency code. **Required**. |
 | `setDate()` | The date to retrieve OHLC data for. This should be formatted as YYYY-MM-DD. **Required**. |
 | `setBase()` | The base currency for the rates. **Default: USD**. |
 | `setInterval()` | The interval for the OHLC candles. One of: `5m`, `15m`, `30m`, `1h`, `4h`, `12h`, `1d`. **Default: 1d**. |

--- a/src/CurrencyApi.php
+++ b/src/CurrencyApi.php
@@ -102,12 +102,12 @@ class CurrencyApi
     protected $end_date = '';
 
     /**
-     * The currency to retrieve OHLC data for.
+     * The quote currency to retrieve OHLC data for.
      * This will be a three letter ISO 4217 currency code.
      *
      * @var string
      */
-    protected $currency = '';
+    protected $quote = '';
 
     /**
      * The interval for OHLC data.
@@ -231,15 +231,15 @@ class CurrencyApi
     }
 
     /**
-     * Sets the currency for the OHLC endpoint
-     * See currency property for description ^
+     * Sets the quote currency for the OHLC endpoint
+     * See quote property for description ^
      *
-     * @param string $currency
+     * @param string $quote
      * @return CurrencyApi
      */
-    public function setCurrency(string $currency) : CurrencyApi
+    public function setQuote(string $quote) : CurrencyApi
     {
-        $this->currency = strtoupper($currency);
+        $this->quote = strtoupper($quote);
         return $this;
     }
 
@@ -374,7 +374,7 @@ class CurrencyApi
     protected function getOhlcParams() : array
     {
         $params = [
-            'currency' => $this->currency,
+            'quote' => $this->quote,
             'date' => $this->date,
         ];
         if ($this->base !== self::DEFAULT_BASE) {

--- a/tests/CurrencyApiTest.php
+++ b/tests/CurrencyApiTest.php
@@ -132,11 +132,11 @@ class CurrencyApiTest extends TestCase
         $this->assertEquals($date, $this->getProtectedProperty($this->currencyApi, 'end_date'));
     }
 
-    public function testSetCurrency()
+    public function testSetQuote()
     {
-        $currency = 'eur';
-        $this->assertEquals($this->currencyApi, $this->currencyApi->setCurrency($currency));
-        $this->assertEquals('EUR', $this->getProtectedProperty($this->currencyApi, 'currency'));
+        $quote = 'eur';
+        $this->assertEquals($this->currencyApi, $this->currencyApi->setQuote($quote));
+        $this->assertEquals('EUR', $this->getProtectedProperty($this->currencyApi, 'quote'));
     }
 
     public function testSetInterval()
@@ -186,30 +186,30 @@ class CurrencyApiTest extends TestCase
 
     public function testGetOhlcParams()
     {
-        $currency = 'EUR';
+        $quote = 'EUR';
         $date = '2023-12-25';
-        $this->currencyApi->setCurrency($currency);
+        $this->currencyApi->setQuote($quote);
         $this->currencyApi->setDate($date);
         $invokedMethod = $this->invokeMethod($this->currencyApi, 'getOhlcParams');
         $this->assertEquals([
-            'currency' => $currency,
+            'quote' => $quote,
             'date' => $date,
         ], $invokedMethod);
     }
 
     public function testGetOhlcParamsWithBaseAndInterval()
     {
-        $currency = 'EUR';
+        $quote = 'EUR';
         $date = '2023-12-25';
         $base = 'GBP';
         $interval = '1h';
-        $this->currencyApi->setCurrency($currency);
+        $this->currencyApi->setQuote($quote);
         $this->currencyApi->setDate($date);
         $this->currencyApi->setBase($base);
         $this->currencyApi->setInterval($interval);
         $invokedMethod = $this->invokeMethod($this->currencyApi, 'getOhlcParams');
         $this->assertEquals([
-            'currency' => $currency,
+            'quote' => $quote,
             'date' => $date,
             'base' => $base,
             'interval' => $interval,


### PR DESCRIPTION
…build

- OHLC endpoint: setCurrency() -> setQuote(), request param currency -> quote
- Update tests, README, CHANGELOG (3.1.0)
- Makefile: test and run use composer:2 image so no build required
- Dockerfile: copy app and default CMD to phpunit for image-based test runs